### PR TITLE
Docs: series step send-time default + sign-up form required-field contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+**This repo is for the v3.1 docs.** It contains the public-facing markdown documentation for VipeCloud API v3.1 — no implementation code. Customers integrate against the documented contract here.
+
+This repository is public. Treat every file in it — including this one — as customer-readable.
+
+## Repository Structure
+
+- Each markdown file documents a specific API resource (e.g., `contacts.md`, `automations.md`, `sign_up_forms.md`)
+- `README.md` — Entry point with overview, authentication, and version information
+- `SUMMARY.md` — Index of all available endpoints
+
+## API Documentation Structure
+
+All endpoint documentation follows this pattern:
+- HTTP method and endpoint path
+- Request parameters (often in table format with: Attribute, type, required, description)
+- Sample request body (JSON)
+- Sample response body (JSON)
+- Common response codes: 200 (success), 422 (validation and many not-found cases under v3.1's contract), 500 (server error)
+
+## Key API Concepts
+
+### Authentication
+- Basic Authentication with base64-encoded `user_email:api_key`
+- API keys managed in Setup section of the VipeCloud account
+- Base URL: `https://v.vipecloud.com/api/v3.1`
+- Rate limit: 10 calls per 2 seconds per user
+- v3.1 accepts `agent_api`-type keys or basic `api`-type keys
+
+### Conventions
+- v3.1 uses `POST /endpoint(/:id)` for both create and update.
+- v3.1 returns `200 OK` for successful sign-up form submission and successful POSTs in general; this is part of the locked contract — see "Stability tier" below.
+
+## Stability tier
+
+**The v3.1 API contract is locked for stability.** Existing customers depend on specific response shapes, status codes, and message text. Any change to v3.1 documentation that alters a customer-visible contract requires explicit user approval — even if the change matches the implementation more closely than the current docs do.
+
+This applies to:
+- **Response message text** — exact strings in `message` fields. Don't reword "Sign-up form not found." to "This sign up form was not found." even if the latter sounds better.
+- **Status codes** — v3.1 uses `200 OK` for successful POSTs and historically returns `422` for some cases. Don't normalize these silently.
+- **Field shapes** — array vs object, snake_case vs the older mixed-case keys, presence/absence of optional fields.
+
+What's safe to update without approval:
+- New endpoints or new fields added to existing endpoints (purely additive).
+- Clarifying prose, examples, and parameter descriptions that don't change behavior.
+- Documenting behavior that already exists in the implementation but was missing from the docs (e.g., the recent `required` default-to-true normalization — the docs added a clarification of behavior already in the implementation).
+
+When in doubt, ask.
+
+## Webhooks
+- Webhook events: email_delivered, email_open, email_click, email_bounce, email_unsubscribe
+- HMAC-SHA256 signature verification with shared secret
+- Requires 200 HTTP response code for acknowledgment
+
+## Test Suite
+
+The integration test suite lives in the implementation repo (sibling of this docs repo). v3.1-specific tests include:
+
+- `SignUpFormFieldsApiV31Test.php` — `GET /sign_up_forms/:id/fields` schema response
+- `SignUpFormSubmissionApiV31Test.php` — `POST /sign_up_forms/:id/data` happy/error paths
+- `SignUpFormDiscoveryApiV31Test.php` — discovery-style end-to-end against an existing form
+
+These tests target v3.1 by way of `SignUpFormFixtures::makeV31Request()`, which sets the v3.1 base URL and auth header for the duration of each call. See the implementation repo's `tests/README.md` for running.
+
+## Common Tasks
+
+When updating API documentation:
+1. Maintain consistent formatting with existing endpoint files.
+2. Use markdown tables for parameter documentation.
+3. Include sample request/response JSON with proper formatting.
+4. Update `SUMMARY.md` if adding new endpoints.
+5. **Source-of-truth check**: cross-reference the implementation to confirm the docs match real behavior — v3.1 has historically drifted from its docs because the stability rule discourages silent updates.
+6. If adding new endpoints, consider adding corresponding tests in the implementation repo's test suite.
+
+## Documentation Standards
+
+- All requests and responses use JSON encoding.
+- All API calls must use HTTPS.
+- Parameter tables include: Attribute name, type, required (yes/no/conditional), description.
+- Code examples use `curl` for portability (the older v3.1 docs sometimes use PHP — both are acceptable, but new examples should use `curl`).
+- Conditional requirements should explain trigger conditions in the description column.
+
+## Git Workflow
+
+- Origin: `https://github.com/VipeCloud/vipecloud_api.git`
+- Default branch: typically `master` (verify with `git branch` before pushing).

--- a/series_templates_steps.md
+++ b/series_templates_steps.md
@@ -10,10 +10,12 @@ delay_days | integer | yes | The number of days to delay this step after the pri
 email_template_id | integer | yes | Email template id
 series_template_id | integer | no | Note the system will automatically assign this value when the series template step id is included in a POST to /series_templates. IMPORTANT: a series template step can only be associated with ONE series template. 
 action | string | no | This value will ALWAYS be set to "send a new email" for series template steps created via the API.
-hour | integer | no | Optionally set the hour of the day this step will process. Disregarded for the first step. No leading zero.
-min | integer | no | Optionally set the minute of the hour this step will process. Disregarded for the first step. No leading zero.
-ampm | enum "am" or "pm" | no | Optionally set the am or pm of the day this step will process. Disregarded for the first step. NOTE to set the time for the step to process EACH of the hour, min, and ampm parameters need to be set.
+hour | integer | no | Optionally set the hour of the day this step will process. Disregarded for the first step. No leading zero. Defaults to 10 on a delayed step launched without a complete send time.
+min | integer | no | Optionally set the minute of the hour this step will process. Disregarded for the first step. No leading zero. Defaults to 00 on a delayed step launched without a complete send time.
+ampm | enum "am" or "pm" | no | Optionally set the am or pm of the day this step will process. Disregarded for the first step. NOTE to set the time for the step to process EACH of the hour, min, and ampm parameters need to be set. Defaults to am on a delayed step launched without a complete send time.
 weekday | boolean | no | Optionally set the step to only process on a weekday.
+
+NOTE on step timing: it is recommended to set an explicit send time (hour, min, and ampm together) on every delayed step. A step with `delay_days` greater than 0 that is launched without a complete send time will process at 10:00 am in the user's local timezone. The first step in a series always processes when the series is launched and disregards these time values.
 
 ```
 POST /series_template_steps(/:id)

--- a/sign_up_forms.md
+++ b/sign_up_forms.md
@@ -255,6 +255,8 @@ This returns custom field definitions including labels, types, and dropdown opti
 
 ### GET /sign_up_forms/:id/fields
 
+> **Required-field contract:** Each field's `required` key is always returned as a boolean. Fields default to `required: true` when the form-builder did not explicitly toggle them off. The `POST /sign_up_forms/:id/data` validator enforces this exact value — the schema you see here matches what the submission endpoint will reject for.
+
 Returns the full schema of a sign-up form: form-level metadata, submittability state, and per-field constraints. Use this endpoint to discover what to send in `POST /sign_up_forms/:id/data`.
 
 ```
@@ -332,7 +334,7 @@ GET /sign_up_forms/:id/fields
 | `slug` | Unique field key. Use this as the key in `POST /data` `fields` body. |
 | `name` | Human-readable label. |
 | `type` | Field type (text, email, phone, url, numeric, Dropdown, Picklist, etc.). |
-| `required` | Whether the field is required. |
+| `required` | Boolean. **Always present** in the response — never absent. `true` when the field must be supplied to submit; `false` only when the form-builder has explicitly toggled the field off. Fields default to `required: true` when the form-builder did not write a value (matches the form-builder UX, where new fields are required by default). The submission validator at `POST /sign_up_forms/:id/data` enforces this exact value — the schema and validator share a single source of truth, so a field shown as `required: true` here will produce a `422 Validation failed.` with `{slug, message}` in `errors[]` when omitted from a submission body. |
 | `validation` | Format validator (email, phone, url, numeric) or null. |
 | `max_length`/`min_length` | Length bounds, or null if unlimited. |
 | `default_value` | Default value, or null. |


### PR DESCRIPTION
## Summary

### Series step send-time default
A delayed series template step (`delay_days` > 0) launched without a complete `hour`/`min`/`ampm` processes at **10:00 am** in the user's local timezone.
- **`series_templates_steps.md`** — per-field defaults on the `hour` (10), `min` (00), `ampm` (am) rows + a "NOTE on step timing".

### Sign-up form required-field contract
- **`sign_up_forms.md`** — clarifies that each field's `required` key is always returned as a boolean, defaulting to `true` when the form-builder did not explicitly toggle it off, and that the submission validator enforces that exact value.
- **`CLAUDE.md`** — adds repo guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### New
- **CLAUDE.md** — Repository guidance document for Claude Code, describing the v3.1 API documentation structure, key concepts (authentication, API conventions), stability tier rules for customer-visible contracts, webhook expectations, test suite locations, and documentation standards for editing API docs.

### Changed
- **series_templates_steps.md** — Added explicit default send-time behavior documentation for delayed series template steps. Steps with `delay_days > 0` that launch without a complete `hour`/`min`/`ampm` specification now document the fallback processing time as 10:00 am in the user's local timezone. Field descriptions updated with per-field defaults (hour=10, min=00, ampm=am). Added a "NOTE on step timing" recommending explicit send-time configuration for every delayed step.

- **sign_up_forms.md** — Clarified the `required`-field contract for `GET /sign_up_forms/:id/fields`. The `required` field is now explicitly documented as always returning a boolean (never absent), defaulting to `true` when not explicitly toggled off in the form builder. Specified that the `POST /sign_up_forms/:id/data` validator enforces this exact behavior, including `422 Validation failed.` response with `{slug, message}` per-field errors when required fields are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->