### PR TITLE
Document custom_fields name keys and task contact-name behavior

### DIFF
--- a/contacts.md
+++ b/contacts.md
@@ -34,9 +34,10 @@ Sample post body below.
    "personal_facebook_url" : "https://www.facebook.com/...",
    "tags" : ["Speedy"], 
    "verify" : 0, //if this is 1 AND you are an enterprise user AND this user has less than 10K verifications this month, we will verify the contact's email address on import
-   "custom_fields" : [ //an array of the custom fields. Key value is the custom field id.
-      id : "value" 
-   ],
+   "custom_fields" : { //an object of custom field values, keyed by custom field id OR field name (names are matched case-insensitively against your account's contact custom fields — use GET /custom_fields to list them). Keys that don't match a custom field on your account are skipped.
+      "528" : "value",
+      "Liquid Assets" : "value"
+   },
    "contact_lists" : [ //an array of contact_list_ids.
       "0" => 123,
       "1" => 1234

--- a/tasks.md
+++ b/tasks.md
@@ -14,7 +14,7 @@ Body params
   "subject" : "Started Trial", //required
   "activity_type" : "their_activity", //required. Can be their_activity or your_activity
   "details" : "Created trial via website", 
-  "contact_tags" : ["BusinessTrial","Annual"], //VipeCloud will create a contact if it doesn't exist. Values must be array
+  "contact_tags" : ["BusinessTrial","Annual"], //VipeCloud will create a contact if it doesn't exist (named from the email address; existing contacts keep their current name). Values must be array
   "source" : "Website signup", //free form
 }
 ```


### PR DESCRIPTION
- `contacts.md`: `custom_fields` is a JSON object keyed by custom field ID or field name (matched case-insensitively against the account's contact custom fields); keys that match no account field are skipped.
- `tasks.md`: POST /tasks creates missing contacts with a name derived from the email address; existing contacts keep their current name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6zRrMUgYtsa7NZ5McTnDV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Changed:** Documented case-insensitive custom field name matching for `POST /contacts`; unmatched keys are skipped.
- **Changed:** Clarified `POST /tasks` contact naming: new contacts use the email address, while existing names are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->