### PR TITLE
text_templates: document that entities in message are resolved to characters

### DIFF
--- a/text_templates.md
+++ b/text_templates.md
@@ -17,6 +17,12 @@ Body params
 }
 ```
 
+`message` is stored and sent as plain text. HTML tags are stripped, and HTML
+entities are resolved to the characters they represent — so a template submitted
+as `you&apos;d like this &amp; more` is stored and texted as `you'd like this & more`.
+Send the characters you want the recipient to receive; there is no need to
+escape them.
+
 Sample response
 ```
 {


### PR DESCRIPTION
Counterpart to **VipeCloud/vc3#4942** (GH VipeCloud/vc3#4867).

The endpoint already documented that HTML is not allowed in `message`, but said nothing about HTML **entities**. They were being stored and texted verbatim, so a body submitted as `you&apos;d` reached the recipient's phone with the entity still in it.

vc3 now decodes entities on this path, which makes behaviour match what this page already promised rather than changing the contract. This adds one clarifying sentence saying so.

No request or response shape changes, no new fields, no validation or error-message changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ysDfGjXQsn2bLwGtjuYtV